### PR TITLE
Remove xvg collection from outputs

### DIFF
--- a/tools/gromacs/sim.xml
+++ b/tools/gromacs/sim.xml
@@ -1,4 +1,4 @@
-<tool id="gmx_sim" name="GROMACS simulation" version="@VERSION@">
+<tool id="gmx_sim" name="GROMACS simulation" version="@VERSION@.1">
     <description>for system equilibration or data collection</description>
     <macros>
         <import>macros.xml</import>
@@ -243,10 +243,13 @@
         <data name="output6" format="edr" from_work_dir="outp.edr">
             <filter>outps["edr_out"] == 'true'</filter>
         </data>
-        <collection name="output7" type="list">
+        <data name="output7" format="xvg" from_work_dir="outp_pullf.xvg">
+            <filter>outps["xvg_out"] == 'true'</filter>
+        </data>
+        <!-- <collection name="output7" type="list">
             <discover_datasets pattern="(?P&lt;designation&gt;.*)\.xvg" visible="true" directory="." />
             <filter>outps["xvg_out"] == 'true'</filter>
-        </collection>
+        </collection> -->
         <data name="output8" format="binary" from_work_dir="outp.tpr">
             <filter>outps["tpr_out"] == 'true'</filter>
         </data>


### PR DESCRIPTION
Due to https://github.com/galaxyproject/pulsar/issues/212, this tool is not currently usable on pulsar for the TMD simulations I want to perform. This is a (hopefully temporary) fix.