### PR TITLE
MM(GB/PB)SA update

### DIFF
--- a/tools/buildtools/ambertools/acpype.xml
+++ b/tools/buildtools/ambertools/acpype.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="2020.07.25.08.41">acpype</requirement>
+        <requirement type="package" version="2020.10.24.12.16">acpype</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         ln -s '$input1' ./input1.${input1.ext} &&

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">20.5</token>
+  <token name="@TOOL_VERSION@">20.15</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -107,7 +107,7 @@ with open("$parameteroutfile",'w+') as f:
                     <param name="cavity_offset" type="float" value="-0.5692" label="Offset value used to correct non-polar free energy contribution" help="Not used for APBS"/>
                     <!-- <param name="cavity_surften" type="float" value="0.0378" label="Surface tension" help="Surface tension in kcal / mol / Å²"/> -->
                     <param name="exdi" type="float" value="80.0" label="External dielectric constant"/>
-                    <param name="indi" type="float" value="0" label="Internal dielectric constant"/>
+                    <param name="indi" type="float" value="1.0" label="Internal dielectric constant"/>
                     <param name="scale" type="float" value="2.0" label="Resolution of the Poisson Boltzmann grid" help="Resolution of the Poisson Boltzmann grid, equal to the reciprocal of the grid spacing."/>
                     <param name="linit" type="integer" value="1000" label="Maximum number of iterations of the linear Poisson Boltzmann equation to try"/>
                     <param name="prbrad" type="select" label="Solvent probe radius in Å">
@@ -126,7 +126,7 @@ with open("$parameteroutfile",'w+') as f:
                     <param name="csv_format" type="boolean" checked="true" truevalue="1" falsevalue="0" label="CSV format" help="Output in CSV format; choose false for unformatted text output"/>
                     <param name="dec_verbose" type="select" value="0" label="Decomposition verbosity" help="Choose verbosity of the decomposition output file. Note that if the verbosity level selected is too high and the parser cannot find the requested information, the job will fail.">
                         <option value="0">DELTA energy, total contribution only</option>
-                        <option value="1">DELTA energy, total, sidechain, and backbone contributions</option>
+                        <option value="1" selected="true">DELTA energy, total, sidechain, and backbone contributions</option>
                         <option value="2">Complex, Receptor, Ligand, and DELTA energies, total contribution only</option>
                         <option value="3">Complex, Receptor, Ligand, and DELTA energies, total, sidechain, and backbone contributions</option>
                     </param>
@@ -196,8 +196,6 @@ with open("$parameteroutfile",'w+') as f:
             </conditional>
             <output name="resultoutfile">
                 <assert_contents>
-                <!-- <has_text text="GENERALIZED BORN:"/>
-                <has_text text="DELTA TOTAL                -56."/> -->
                 <has_text text="POISSON BOLTZMANN:"/>
                 <has_text text="DELTA TOTAL                -47"/>
                 </assert_contents>
@@ -206,7 +204,7 @@ with open("$parameteroutfile",'w+') as f:
                 <assert_contents>
                     <has_text text="idecomp = 1: Per-residue decomp adding 1-4 interactions to Internal"/>
                     <has_text text="HIE 240,R HIE 240"/>
-                    <!-- <has_text text="RAL 241,L RAL   1,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0"/> -->
+                    <has_text text="RAL 241,L RAL   1,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0"/>
                 </assert_contents>
             </output>
         </test>
@@ -246,7 +244,6 @@ If simulations were performed using the Galaxy GROMACS tools, the topology (in t
 - The `AmberTools Manual`_
 - The `Amber Tutorial`_ on using MMPBSA.py
 - There are many more complex flags available. This Galaxy wrapper only supports GB and PB binding free energies and decomposition. Parallel calculations are not supported at present.
-- This Galaxy tool is based on MMPBSA.py. More details on options that are not described in the Manual and Tutorials can be found in the code - see "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/input_parser.py" and "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/main.py".
 
 .. _`Amber Tutorial`: http://ambermd.org/tutorials/advanced/tutorial3/py_script/index.htm
 .. _`AmberTools Manual`: https://ambermd.org/doc12/Amber18.pdf

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -1,6 +1,5 @@
-<tool id="mmpbsa_mmgbsa" name="mmpbsa mmgbsa" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
-    <description>- estimate ligand binding affinities
-    </description>
+<tool id="mmpbsa_mmgbsa" name="MMPBSA/MMGBSA" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
+    <description>tool for estimating ligand binding affinities</description>
     <macros>
         <import>macros.xml</import>
         <token name="@GALAXY_VERSION@">0</token>
@@ -72,7 +71,7 @@ with open("$parameteroutfile",'w+') as f:
             <param name="endframe" type="integer" value="9999999" label="Final frame to analyse" min="1" max="100000000"/>
             <param name="interval" type="integer" value="1" label="Interval between frames analyzed" min="1" max="10000"/>
             <param name="entropy" type="boolean" checked="true" truevalue="1" falsevalue="0" label="Perform quasi-harmonic entropy calculation?" help="Calculate the quasi-harmonic entropy"/>
-            <param name="use_sander" type="boolean" checked="false" label="Use sander" truevalue="1" falsevalue="0" help="Forces MMPBSA.py to use sander for energy calculations, even when mmpbsa_py_energy will suffice."/>
+            <param name="use_sander" type="boolean" checked="false" label="Use sander" truevalue="1" falsevalue="0" help="Forces MMPBSA.py to use sander for energy calculations, even when mmpbsa_py_energy will suffice. Default behavior is to use mmpbsa_py_energy where possible."/>
             <param name="keep_files" type="boolean" checked="false" truevalue="1" falsevalue="0" label="Keep additional files?" help="If specified, temporary files will be kept and stored in a collection, which may be helpful for debugging."/>
             <param name="strip_mask" type="text" value=":WAT:Cl-:Na+" label="Strip mask" help="Enter a mask for removing unneeded atoms (water and ions) from the solvated prmtop file"/>
         </section>
@@ -84,7 +83,7 @@ with open("$parameteroutfile",'w+') as f:
                 </param>
                 <when value="gb">
                     <param name="igb" type="select" value="5" label="GB model to use (igb)" help="5 options are available. Consult the AmberTools manual for more details. Note that some missing values (e.g. 3 and 4) are no longer supported.">
-                        <option value="0">0 - no generalized Born term is used</option>
+                        <!-- <option value="0">0 - no generalized Born term is used</option> -->
                         <option value="1">1 - Basic pairwise generalized Born model</option>
                         <option value="2">2 - OBC model</option>
                         <option value="5">5 - alternative OBC model</option>
@@ -92,12 +91,30 @@ with open("$parameteroutfile",'w+') as f:
                         <option value="8">8 - alternative GBn model</option>
                     </param>
                     <param name="saltcon" type="float" value="0" label="Salt concentration (M)" min="0.0" max="6.0"/>
+                    <param name="surfoff" type="float" value="0" label="Offset to correct (by addition) the value of the non-polar contribution to the solvation free energy term"/>
+                    <!-- <param name="surften" type="float" value="0.0072" label="Surface tension">
+                        <help><![CDATA[Surface tension in kcal / mol / Å<sup>2</sup>]]></help>
+                    </param> -->
+                    <param name="molsurf" type="boolean" checked="false" truevalue="1" falsevalue="0" label="Use the molsurf algorithm to calculate the surface area for the nonpolar solvation term?" help="The default behavior is to use LCPO (Linear Combination of Pairwise Overlaps)."/>
+                    <param name="probe" type="float" value="1.4" label="Radius of the probe molecule (supposed to be the size of a solvent molecule), in Å, to use when determining the molecular surface" help="Only applicable when the molsurf algorithm is selected." min="0"/>
+                    <param name="msoffset" type="float" value="0" label="Offset to apply to the individual atomic radii in the system when calculating the molsurf surface." />
                 </when>
                 <when value="pb">
                     <param name="istrng" type="float" value="0.15" label="Ionic strength (M)" min="0.0" max="2.0"/>
                     <param name="fillratio" type="float" value="4.0" label="Fill ratio" help="The ratio between the longest dimension of the rectangular finite-difference grid and that of the solute" min="0.0" max="10.0"/>
                     <param name="inp" type="integer" value="1" label="Nonpolar solvation method" min="1" max="2" help="1 - default"/>
                     <param name="radiopt" type="integer" value="0" label="Use optimized radii?" min="0" max="2" help="0 - default do not use these"/>
+                    <param name="cavity_offset" type="float" value="-0.5692" label="Offset value used to correct non-polar free energy contribution" help="Not used for APBS"/>
+                    <!-- <param name="cavity_surften" type="float" value="0.0378" label="Surface tension" help="Surface tension in kcal / mol / Å²"/> -->
+                    <param name="exdi" type="float" value="80.0" label="External dielectric constant"/>
+                    <param name="indi" type="float" value="0" label="Internal dielectric constant"/>
+                    <param name="scale" type="float" value="2.0" label="Resolution of the Poisson Boltzmann grid" help="Resolution of the Poisson Boltzmann grid, equal to the reciprocal of the grid spacing."/>
+                    <param name="linit" type="integer" value="1000" label="Maximum number of iterations of the linear Poisson Boltzmann equation to try"/>
+                    <param name="prbrad" type="select" label="Solvent probe radius in Å">
+                        <option value="1.4" selected="True">1.4</option>
+                        <option value="1.6">1.6</option>
+                    </param>
+                    <!-- <param name="sander_apbs" type="boolean" truevalue="1" falsevalue="0" label="" help=""/> -->
                 </when>
             </conditional>
             <conditional name="decomposition">
@@ -114,10 +131,10 @@ with open("$parameteroutfile",'w+') as f:
                         <option value="3">Complex, Receptor, Ligand, and DELTA energies, total, sidechain, and backbone contributions</option>
                     </param>
                     <param name="idecomp" type="select" value="1" label="Energy decomposition scheme to use" help="Choose an energy decomposition scheme.">
-                        <option value="1">Per-residue decomp with 1-4 terms added to internal potential terms</option>
-                        <option value="2">Per-residue decomp with 1-4 EEL added to EEL and 1-4 VDW added to VDW potential terms.</option>
-                        <option value="3">Pairwise decomp with 1-4 terms added to internal potential terms</option>
-                        <option value="4">Pairwise decomp with 1-4 EEL added to EEL and 1-4 VDW added to VDW potential terms</option>
+                        <option value="1">1 - Per-residue decomp with 1-4 terms added to internal potential terms</option>
+                        <option value="2">2 - Per-residue decomp with 1-4 EEL added to EEL and 1-4 VDW added to VDW potential terms.</option>
+                        <option value="3">3 - Pairwise decomp with 1-4 terms added to internal potential terms</option>
+                        <option value="4">4 - Pairwise decomp with 1-4 EEL added to EEL and 1-4 VDW added to VDW potential terms</option>
                     </param>
                 </when>
                 <when value="no"/>
@@ -142,8 +159,8 @@ with open("$parameteroutfile",'w+') as f:
             <param name="complex" value="complex.prmtop" ftype="txt"/>
             <param name="trajcomplex" value="1err_desolvated_mini.nc" ftype="netcdf"/>
             <conditional name="allparams">
-                <param name="entropy" value="false"/>
-                <param name="keep_files" value="true"/>
+                <param name="entropy" value="0"/>
+                <param name="keep_files" value="1"/>
             </conditional>
             <conditional name="gb_pb_calc">
                 <param name="calctype" value="gb"/>
@@ -168,15 +185,10 @@ with open("$parameteroutfile",'w+') as f:
             <conditional name="allparams">
                 <param name="startframe" value="1"/>
                 <param name="endframe" value="1"/>
-                <param name="entropy" value="false"/>
+                <param name="entropy" value="0"/>
             </conditional>
-            <conditional name="gbcalc">
-                <param name="calctype" value="yes"/>
-                <param name="igb" value="2"/>
-                <param name="saltcon" value="0.100"/>
-            </conditional>
-            <conditional name="pbcalc">
-                <param name="calctype" value="yes"/>
+            <conditional name="gb_pb_calc">
+                <param name="calctype" value="pb"/>
                 <param name="istrng" value="0.100"/>
             </conditional>
             <conditional name="decomposition">
@@ -184,17 +196,17 @@ with open("$parameteroutfile",'w+') as f:
             </conditional>
             <output name="resultoutfile">
                 <assert_contents>
-                <has_text text="GENERALIZED BORN:"/>
-                <has_text text="DELTA TOTAL                -56."/>
+                <!-- <has_text text="GENERALIZED BORN:"/>
+                <has_text text="DELTA TOTAL                -56."/> -->
                 <has_text text="POISSON BOLTZMANN:"/>
                 <has_text text="DELTA TOTAL                -47"/>
                 </assert_contents>
             </output>
             <output name="decompoutfile">
                 <assert_contents>
-                <has_text text="idecomp = 1: Per-residue decomp adding 1-4 interactions to Internal"/>
-                <has_text text="HIE 240,R HIE 240"/>
-                <has_text text="RAL 241,L RAL   1,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0"/>
+                    <has_text text="idecomp = 1: Per-residue decomp adding 1-4 interactions to Internal"/>
+                    <has_text text="HIE 240,R HIE 240"/>
+                    <!-- <has_text text="RAL 241,L RAL   1,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0"/> -->
                 </assert_contents>
             </output>
         </test>
@@ -236,27 +248,8 @@ If simulations were performed using the Galaxy GROMACS tools, the topology (in t
 - There are many more complex flags available. This Galaxy wrapper only supports GB and PB binding free energies and decomposition. Parallel calculations are not supported at present.
 - This Galaxy tool is based on MMPBSA.py. More details on options that are not described in the Manual and Tutorials can be found in the code - see "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/input_parser.py" and "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/main.py".
 
-.. class:: infomark
-
-**Test data**
-
-- The test data for this tool comes from an `Amber Tutorial`_ and the original dataset_ is available.
-- For convenience, water has been stripped from the .mdcrd trajectory and this has been converted to netcdf format.
-
-.. code-block:: python
-
-  import mdtraj as md
-  traj = md.load('1err_prod.mdcrd', top='1err.solvated.prmtop')
-  topology = traj.topology
-  atoms_to_keep = topology.select('not water')
-  traj.restrict_atoms(atoms_to_keep)
-  traj.save('1err_desolvated.nc')
-  traj[0:2].save('1err_desolvated_mini.nc')
-
-
 .. _`Amber Tutorial`: http://ambermd.org/tutorials/advanced/tutorial3/py_script/index.htm
 .. _`AmberTools Manual`: https://ambermd.org/doc12/Amber18.pdf
-.. _dataset: http://ambermd.org/tutorials/advanced/tutorial3/py_script/files/Est_Rec_top_mdcrd.tgz
 
     ]]></help>
     <expand macro="citations">

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -77,7 +77,7 @@ with open("$parameteroutfile",'w+') as f:
       <param name="endframe" type="integer" value="9999999" label="Final frame to analyse" min="1" max="100000000"/>
       <param name="interval" type="integer" value="1" label="interval between frames analysed" min="1" max="10000"/>
       <param name="entropy" type="boolean" checked="true" truevalue="1" falsevalue="0" label="quasi-harmonic entropy calculation" help="Calculate the quasi-harmonic entropy"/>
-      <param name="use_sander" type="boolean" checked="false" label="use sander" truevalue="1" falsevalue="0" help="defaults to false (will use sander if needed)."/>
+      <param name="use_sander" type="boolean" checked="false" label="use sander" truevalue="1" falsevalue="0" help="Forces MMPBSA.py to use sander for energy calculations, even when mmpbsa_py_energy will suffice."/>
       <param name="verbose" type="integer" value="2" label="verbosity" min="0" max="3" help="0 - not verbose 3 - ultra verbose"/>
       <param name="keep_files" type="boolean" checked="false" truevalue="1" falsevalue="0" label="keep additional files" help="defaults to false, no extra files kept"/>
       <param name="strip_mask" type="text" value=":WAT:Cl-:Na+" label="Strip mask" help="Enter a mask for removing unneeded atoms (water/ions)from the solvated prmtop"/>
@@ -89,8 +89,14 @@ with open("$parameteroutfile",'w+') as f:
           <option value="no">no</option>
         </param>
         <when value="yes">
-          <param name="igb" type="integer" value="5" label="igb GB model" min="0" max="7" help="5 - default"/>
-          <param name="saltcon" type="float" value="0.150" label="Salt Concentration (M)" min="0.0" max="2.0"/>
+          <param name="igb" type="select" value="5" label="Generalized GB model to use" min="0" max="7" help="5 - default">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="5">5</option>
+            <option value="7">7</option>
+            <option value="8">8</option>
+          </param>
+          <param name="saltcon" type="float" value="0" label="Salt Concentration (M)" min="0.0" max="6.0"/>
         </when>
         <when value="no"></when>
       </conditional>

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -1,31 +1,26 @@
 <tool id="mmpbsa_mmgbsa" name="mmpbsa mmgbsa" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
-  <description>- estimate ligand binding affinities
-  </description>
-  <macros>
-    <import>macros.xml</import>
-    <token name="@GALAXY_VERSION@">0</token>
-  </macros>
-  <expand macro="requirements">
-    <requirement type="package" version="2.11.2">jinja2</requirement>
-  </expand>
-  <command detect_errors="exit_code">
-    <![CDATA[
-    python '$mmpbsa_script' '$inputs' &&
-    PATH_TO_MMPBSA=\$(dirname `which MMPBSA.py`) &&
-    export AMBERHOME=\$(dirname \$PATH_TO_MMPBSA) &&
-    #if $input.simulation.solvatedcomplex:
-        MMPBSA.py -O -i '$parameteroutfile' -sp '$input.simulation.solvatedcomplex' -cp '$input.simulation.complex' -rp '$input.simulation.receptor' -lp '$input.simulation.ligand' -y '$input.simulation.trajcomplex' -o '$resultoutfile' -do '$decompoutfile'
-    #else:
-        MMPBSA.py -O -i '$parameteroutfile' -cp '$input.simulation.complex' -rp '$input.simulation.receptor' -lp '$input.simulation.ligand' -y '$input.simulation.trajcomplex' -o '$resultoutfile' -do '$decompoutfile'
-    #end if
-
-    ]]>
-  </command>
-  <configfiles>
-    <inputs name="inputs"/>
-    <configfile name="mmpbsa_script">
-      <![CDATA[
-
+    <description>- estimate ligand binding affinities
+    </description>
+    <macros>
+        <import>macros.xml</import>
+        <token name="@GALAXY_VERSION@">0</token>
+    </macros>
+    <expand macro="requirements">
+        <requirement type="package" version="2.11.2">jinja2</requirement>
+    </expand>
+    <command detect_errors="exit_code"><![CDATA[
+        python '$mmpbsa_script' '$inputs' &&
+        PATH_TO_MMPBSA=\$(dirname `which MMPBSA.py`) &&
+        export AMBERHOME=\$(dirname \$PATH_TO_MMPBSA) &&
+        #if $input.simulation.solvatedcomplex:
+            MMPBSA.py -O -i '$parameteroutfile' -sp '$input.simulation.solvatedcomplex' -cp '$input.simulation.complex' -rp '$input.simulation.receptor' -lp '$input.simulation.ligand' -y '$input.simulation.trajcomplex' -o '$resultoutfile' -do '$decompoutfile'
+        #else:
+            MMPBSA.py -O -i '$parameteroutfile' -cp '$input.simulation.complex' -rp '$input.simulation.receptor' -lp '$input.simulation.ligand' -y '$input.simulation.trajcomplex' -o '$resultoutfile' -do '$decompoutfile'
+        #end if
+    ]]></command>
+    <configfiles>
+        <inputs name="inputs"/>
+        <configfile name="mmpbsa_script"><![CDATA[
 import os
 import sys
 import json
@@ -44,217 +39,215 @@ print(params)
 with open("$parameteroutfile",'w+') as f:
     f.write(template.render(params))
 
-]]>
-    </configfile>
-  </configfiles>
-  <inputs>
-    <section name="input" title="Input" expanded="true">
-      <conditional name="simulation">
-        <param name="simtype" type="select" label="Single or Multiple Trajectories" help="For a single complex in water choose Single. For complex, receptor and ligand trajectories choose multiple">
-          <option selected="True" value="single">Single Trajectory Protocol (STP)</option>
-          <option value="multiple">Multiple Trajectory Protocol (MTP)</option>
-        </param>
-        <when value="single">
-          <param format="txt" name="ligand" type="data" label="AMBER prmtop input for Ligand"/>
-          <param format="txt" name="receptor" type="data" label="AMBER prmtop input for Receptor"/>
-          <param format="txt" name="complex" type="data" label="AMBER prmtop input for Complex"/>
-          <param format="txt" optional="true" name="solvatedcomplex" type="data" label="AMBER prmtop input for Solvated Complex" help="This is optional. Not required if trajectory already has solvent removed"/>
-          <param format="netcdf" name="trajcomplex" type="data" label="NetCDF trajectory input for Complex" help="Trajectory of the (solvated) complex"/>
-        </when>
-        <when value="multiple">
-          <param format="txt" name="ligand" type="data" label="AMBER prmtop input for Ligand"/>
-          <param format="txt" name="receptor" type="data" label="AMBER prmtop input for Receptor"/>
-          <param format="txt" name="complex" type="data" label="AMBER prmtop input for Complex"/>
-          <param format="txt" optional="true" name="solvatedcomplex" type="data" label="AMBER prmtop input for Solvated Complex" help="This is optional. Not required if trajectory alraeady has solvent removed"/>
-          <param format="netcdf" name="trajligand" type="data" label="NetCDF trajectory input for Ligand"/>
-          <param format="netcdf" name="trajreceptor" type="data" label="NetCDF trajectory input for Receptor"/>
-          <param format="netcdf" name="trajcomplex" type="data" label="NetCDF trajectory input for Complex"/>
-        </when>
-      </conditional>
-    </section>
-    <section name="allparams" title="General parameters" expanded="false">
-      <param name="startframe" type="integer" value="1" label="First frame to analyse" min="1" max="100000000"/>
-      <param name="endframe" type="integer" value="9999999" label="Final frame to analyse" min="1" max="100000000"/>
-      <param name="interval" type="integer" value="1" label="interval between frames analysed" min="1" max="10000"/>
-      <param name="entropy" type="boolean" checked="true" truevalue="1" falsevalue="0" label="quasi-harmonic entropy calculation" help="Calculate the quasi-harmonic entropy"/>
-      <param name="use_sander" type="boolean" checked="false" label="use sander" truevalue="1" falsevalue="0" help="Forces MMPBSA.py to use sander for energy calculations, even when mmpbsa_py_energy will suffice."/>
-      <param name="verbose" type="integer" value="2" label="verbosity" min="0" max="3" help="0 - not verbose 3 - ultra verbose"/>
-      <param name="keep_files" type="boolean" checked="false" truevalue="1" falsevalue="0" label="keep additional files" help="defaults to false, no extra files kept"/>
-      <param name="strip_mask" type="text" value=":WAT:Cl-:Na+" label="Strip mask" help="Enter a mask for removing unneeded atoms (water/ions)from the solvated prmtop"/>
-    </section>
-    <section name="calcdetails" title="Details of calculation and parameters" expanded="true">
-      <conditional name="gbcalc">
-        <param name="calctype" type="select" label="General Born calculation" help="Choose carry out General Born Calculation">
-          <option selected="True" value="yes">yes</option>
-          <option value="no">no</option>
-        </param>
-        <when value="yes">
-          <param name="igb" type="select" value="5" label="Generalized GB model to use" min="0" max="7" help="5 - default">
-            <option value="1">1</option>
-            <option value="2">2</option>
-            <option value="5">5</option>
-            <option value="7">7</option>
-            <option value="8">8</option>
-          </param>
-          <param name="saltcon" type="float" value="0" label="Salt Concentration (M)" min="0.0" max="6.0"/>
-        </when>
-        <when value="no"></when>
-      </conditional>
-      <conditional name="pbcalc">
-        <param name="calctype" type="select" label="Poisson Boltzman calculation" help="Choose carry out Poisson Boltzman Calculation">
-          <option value="yes">yes</option>
-          <option selected="True" value="no">no</option>
-        </param>
-        <when value="yes">
-          <param name="istrng" type="float" value="0.15" label="Ionic Strength (M)" min="0.0" max="2.0"/>
-          <param name="fillratio" type="float" value="4.0" label="Fill ratio" help="The ratio between the longest dimension of the rectangular finite-difference grid and that of the solute" min="0.0" max="10.0"/>
-          <param name="inp" type="integer" value="1" label="Nonpolar solvation method" min="1" max="2" help="1 - default"/>
-          <param name="radiopt" type="integer" value="0" label="Use optimized radii?" min="0" max="2" help="0 - default do not use these"/>
-        </when>
-        <when value="no"></when>
-      </conditional>
-      <conditional name="decomposition">
-        <param name="decomposition" type="select" label="Decomposition Analysis" help="Choose to carry out decomposition analysis">
-          <option selected="True" value="yes">yes</option>
-          <option value="no">no</option>
-        </param>
-        <when value="yes">
-          <param name="csv_format" type="boolean" checked="true" truevalue="1" falsevalue="0" label="CSV format" help="Defaults to true, CSV format. Choose false for unformatted text output"/>
-          <param name="dec_verbose" type="integer" value="1" label="Decomposition Verbosity" min="0" max="2" help="choose how verbose the output is. 0 - not verbose, 2- very verbose"/>
-          <param name="idecomp" type="integer" value="1" label="Energy Decomposition Scheme" min="1" max="4" help="choose an energy decomposition scheme. 1 - 2 - 3 - 4"/>
-        </when>
-        <when value="no"></when>
-      </conditional>
-    </section>
-  </inputs>
-  <outputs>
-    <data format="txt" name="resultoutfile" label="${tool.name}: Statistics"/>
-    <data format="txt" name="decompoutfile" label="${tool.name}: Decomposition Statistics"/>
-    <data format="txt" name="parameteroutfile" label="${tool.name}: parameter output"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="ligand" value="ligand.prmtop" ftype="txt"/>
-      <param name="receptor" value="receptor.prmtop" ftype="txt"/>
-      <param name="complex" value="complex.prmtop" ftype="txt"/>
-      <param name="trajcomplex" value="1err_desolvated_mini.nc" ftype="netcdf"/>
-      <conditional name="allparams">
-        <param name="entropy" value="false"/>
-      </conditional>
-      <conditional name="gbcalc">
-        <param name="calctype" value="yes"/>
-        <param name="igb" value="2"/>
-        <param name="saltcon" value="0.100"/>
-      </conditional>
-      <conditional name="decomposition">
-        <param name="decomposition" value="no"/>
-      </conditional>
-      <output name="resultoutfile">
-        <assert_contents>
-          <has_text text="GENERALIZED BORN:"/>
-          <has_text text="DELTA TOTAL                -53."/>
-        </assert_contents>
-      </output>
-    </test>
-    <test>
-      <param name="ligand" value="ligand.prmtop" ftype="txt"/>
-      <param name="receptor" value="receptor.prmtop" ftype="txt"/>
-      <param name="complex" value="complex.prmtop" ftype="txt"/>
-      <param name="trajcomplex" value="1err_desolvated_mini.nc" ftype="netcdf"/>
-      <conditional name="allparams">
-        <param name="startframe" value="1"/>
-        <param name="endframe" value="1"/>
-        <param name="entropy" value="false"/>
-      </conditional>
-      <conditional name="gbcalc">
-        <param name="calctype" value="yes"/>
-        <param name="igb" value="2"/>
-        <param name="saltcon" value="0.100"/>
-      </conditional>
-      <conditional name="pbcalc">
-        <param name="calctype" value="yes"/>
-        <param name="istrng" value="0.100"/>
-      </conditional>
-      <conditional name="decomposition">
-        <param name="decomposition" value="yes"/>
-      </conditional>
-      <output name="resultoutfile">
-        <assert_contents>
-          <has_text text="GENERALIZED BORN:"/>
-          <has_text text="DELTA TOTAL                -56."/>
-          <has_text text="POISSON BOLTZMANN:"/>
-          <has_text text="DELTA TOTAL                -47"/>
-        </assert_contents>
-      </output>
-      <output name="decompoutfile">
-        <assert_contents>
-          <has_text text="idecomp = 1: Per-residue decomp adding 1-4 interactions to Internal"/>
-          <has_text text="HIE 240,R HIE 240"/>
-          <has_text text="RAL 241,L RAL   1,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0"/>
-        </assert_contents>
-      </output>
-    </test>
-  </tests>
-  <help>
-    <![CDATA[
-    .. class:: infomark
 
-    **What it does**
+        ]]></configfile>
+    </configfiles>
+    <inputs>
+        <section name="input" title="Input" expanded="true">
+            <conditional name="simulation">
+                <param name="simtype" type="select" label="Single or Multiple Trajectories" help="For a single complex in water choose Single. For complex, receptor and ligand trajectories choose multiple">
+                    <option selected="True" value="single">Single Trajectory Protocol (STP)</option>
+                    <option value="multiple">Multiple Trajectory Protocol (MTP)</option>
+                </param>
+                <when value="single">
+                    <param format="txt" name="ligand" type="data" label="AMBER prmtop input for Ligand"/>
+                    <param format="txt" name="receptor" type="data" label="AMBER prmtop input for Receptor"/>
+                    <param format="txt" name="complex" type="data" label="AMBER prmtop input for Complex"/>
+                    <param format="txt" optional="true" name="solvatedcomplex" type="data" label="AMBER prmtop input for Solvated Complex" help="This is optional. Not required if trajectory already has solvent removed"/>
+                    <param format="netcdf" name="trajcomplex" type="data" label="NetCDF trajectory input for Complex" help="Trajectory of the (solvated) complex"/>
+                </when>
+                <when value="multiple">
+                    <param format="txt" name="ligand" type="data" label="AMBER prmtop input for Ligand"/>
+                    <param format="txt" name="receptor" type="data" label="AMBER prmtop input for Receptor"/>
+                    <param format="txt" name="complex" type="data" label="AMBER prmtop input for Complex"/>
+                    <param format="txt" optional="true" name="solvatedcomplex" type="data" label="AMBER prmtop input for Solvated Complex" help="This is optional. Not required if trajectory alraeady has solvent removed"/>
+                    <param format="netcdf" name="trajligand" type="data" label="NetCDF trajectory input for Ligand"/>
+                    <param format="netcdf" name="trajreceptor" type="data" label="NetCDF trajectory input for Receptor"/>
+                    <param format="netcdf" name="trajcomplex" type="data" label="NetCDF trajectory input for Complex"/>
+                </when>
+            </conditional>
+        </section>
+        <section name="allparams" title="General parameters" expanded="false">
+            <param name="startframe" type="integer" value="1" label="First frame to analyse" min="1" max="100000000"/>
+            <param name="endframe" type="integer" value="9999999" label="Final frame to analyse" min="1" max="100000000"/>
+            <param name="interval" type="integer" value="1" label="interval between frames analysed" min="1" max="10000"/>
+            <param name="entropy" type="boolean" checked="true" truevalue="1" falsevalue="0" label="quasi-harmonic entropy calculation" help="Calculate the quasi-harmonic entropy"/>
+            <param name="use_sander" type="boolean" checked="false" label="use sander" truevalue="1" falsevalue="0" help="Forces MMPBSA.py to use sander for energy calculations, even when mmpbsa_py_energy will suffice."/>
+            <param name="verbose" type="integer" value="2" label="verbosity" min="0" max="3" help="0 - not verbose 3 - ultra verbose"/>
+            <param name="keep_files" type="boolean" checked="false" truevalue="1" falsevalue="0" label="keep additional files" help="defaults to false, no extra files kept"/>
+            <param name="strip_mask" type="text" value=":WAT:Cl-:Na+" label="Strip mask" help="Enter a mask for removing unneeded atoms (water/ions)from the solvated prmtop"/>
+        </section>
+        <section name="calcdetails" title="Details of calculation and parameters" expanded="true">
+            <conditional name="gbcalc">
+                <param name="calctype" type="select" label="General Born calculation" help="Choose carry out General Born Calculation">
+                    <option selected="True" value="yes">yes</option>
+                    <option value="no">no</option>
+                </param>
+                <when value="yes">
+                    <param name="igb" type="select" value="5" label="Generalized GB model to use" min="0" max="7" help="5 - default">
+                        <option value="1">1</option>
+                        <option value="2">2</option>
+                        <option value="5">5</option>
+                        <option value="7">7</option>
+                        <option value="8">8</option>
+                    </param>
+                    <param name="saltcon" type="float" value="0" label="Salt Concentration (M)" min="0.0" max="6.0"/>
+                </when>
+                <when value="no"/>
+            </conditional>
+            <conditional name="pbcalc">
+                <param name="calctype" type="select" label="Poisson Boltzman calculation" help="Choose carry out Poisson Boltzman Calculation">
+                    <option value="yes">yes</option>
+                    <option selected="True" value="no">no</option>
+                </param>
+                <when value="yes">
+                    <param name="istrng" type="float" value="0.15" label="Ionic Strength (M)" min="0.0" max="2.0"/>
+                    <param name="fillratio" type="float" value="4.0" label="Fill ratio" help="The ratio between the longest dimension of the rectangular finite-difference grid and that of the solute" min="0.0" max="10.0"/>
+                    <param name="inp" type="integer" value="1" label="Nonpolar solvation method" min="1" max="2" help="1 - default"/>
+                    <param name="radiopt" type="integer" value="0" label="Use optimized radii?" min="0" max="2" help="0 - default do not use these"/>
+                </when>
+                <when value="no"/>
+            </conditional>
+            <conditional name="decomposition">
+                <param name="decomposition" type="select" label="Decomposition Analysis" help="Choose to carry out decomposition analysis">
+                    <option selected="True" value="yes">yes</option>
+                    <option value="no">no</option>
+                </param>
+                <when value="yes">
+                    <param name="csv_format" type="boolean" checked="true" truevalue="1" falsevalue="0" label="CSV format" help="Defaults to true, CSV format. Choose false for unformatted text output"/>
+                    <param name="dec_verbose" type="integer" value="1" label="Decomposition Verbosity" min="0" max="2" help="choose how verbose the output is. 0 - not verbose, 2- very verbose"/>
+                    <param name="idecomp" type="integer" value="1" label="Energy Decomposition Scheme" min="1" max="4" help="choose an energy decomposition scheme. 1 - 2 - 3 - 4"/>
+                </when>
+                <when value="no"/>
+            </conditional>
+        </section>
+    </inputs>
+    <outputs>
+        <data format="txt" name="resultoutfile" label="${tool.name}: Statistics"/>
+        <data format="txt" name="decompoutfile" label="${tool.name}: Decomposition Statistics"/>
+        <data format="txt" name="parameteroutfile" label="${tool.name}: parameter output"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="ligand" value="ligand.prmtop" ftype="txt"/>
+            <param name="receptor" value="receptor.prmtop" ftype="txt"/>
+            <param name="complex" value="complex.prmtop" ftype="txt"/>
+            <param name="trajcomplex" value="1err_desolvated_mini.nc" ftype="netcdf"/>
+            <conditional name="allparams">
+                <param name="entropy" value="false"/>
+            </conditional>
+            <conditional name="gbcalc">
+                <param name="calctype" value="yes"/>
+                <param name="igb" value="2"/>
+                <param name="saltcon" value="0.100"/>
+            </conditional>
+            <conditional name="decomposition">
+                <param name="decomposition" value="no"/>
+            </conditional>
+            <output name="resultoutfile">
+                <assert_contents>
+                <has_text text="GENERALIZED BORN:"/>
+                <has_text text="DELTA TOTAL                -53."/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="ligand" value="ligand.prmtop" ftype="txt"/>
+            <param name="receptor" value="receptor.prmtop" ftype="txt"/>
+            <param name="complex" value="complex.prmtop" ftype="txt"/>
+            <param name="trajcomplex" value="1err_desolvated_mini.nc" ftype="netcdf"/>
+            <conditional name="allparams">
+                <param name="startframe" value="1"/>
+                <param name="endframe" value="1"/>
+                <param name="entropy" value="false"/>
+            </conditional>
+            <conditional name="gbcalc">
+                <param name="calctype" value="yes"/>
+                <param name="igb" value="2"/>
+                <param name="saltcon" value="0.100"/>
+            </conditional>
+            <conditional name="pbcalc">
+                <param name="calctype" value="yes"/>
+                <param name="istrng" value="0.100"/>
+            </conditional>
+            <conditional name="decomposition">
+                <param name="decomposition" value="yes"/>
+            </conditional>
+            <output name="resultoutfile">
+                <assert_contents>
+                <has_text text="GENERALIZED BORN:"/>
+                <has_text text="DELTA TOTAL                -56."/>
+                <has_text text="POISSON BOLTZMANN:"/>
+                <has_text text="DELTA TOTAL                -47"/>
+                </assert_contents>
+            </output>
+            <output name="decompoutfile">
+                <assert_contents>
+                <has_text text="idecomp = 1: Per-residue decomp adding 1-4 interactions to Internal"/>
+                <has_text text="HIE 240,R HIE 240"/>
+                <has_text text="RAL 241,L RAL   1,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help><![CDATA[
 
-    This tool calculates the Molecular Mechanics Poisson-Boltzman Surface Area (MMPBSA) which is an estimate of the binding free energy between a ligand and a receptor.
+.. class:: infomark
 
-    .. class:: infomark
+**What it does**
 
-    **How it works**
+This tool calculates the Molecular Mechanics Poisson-Boltzman Surface Area (MMPBSA) which is an estimate of the binding free energy between a ligand and a receptor.
 
-    Prior to using this tool simulations of the ligand complexed with the receptor must be run. This tool, which wraps AmberTools will need a prmtop (Amber style parameter topology file for the receptor, ligand and the complex) and the trajectory in netCDF format.
+.. class:: infomark
 
-    - Single Trajectory Estimate: A simulation of the complex in water is run in advance. The trajectory of this complex is used to estimate the MMPBSA or MMGBSA depending on the options chosen. A General Born (GB) calculation is recommended as this calculation finishes quickly.
-    - Multiple Trajectory Estimate: A simulation of the complex in water, the receptor in water and the ligand in water are run in advance. This is useful the ligand is expected to have a significantly different conformation in solution vs in the complex. The trajectory of this complex is used to estimate the MMPBSA or MMGBSA depending on the options chosen. A General Born (GB) calculation is recommended as this calculation finishes quickly.
+**How it works**
 
-    .. class:: infomark
+Prior to using this tool simulations of the ligand complexed with the receptor must be run. This tool, which wraps AmberTools will need a prmtop (Amber style parameter topology file for the receptor, ligand and the complex) and the trajectory in netCDF format.
 
-    **Outputs created**
+- Single Trajectory Estimate: A simulation of the complex in water is run in advance. The trajectory of this complex is used to estimate the MMPBSA or MMGBSA depending on the options chosen. A General Born (GB) calculation is recommended as this calculation finishes quickly.
+- Multiple Trajectory Estimate: A simulation of the complex in water, the receptor in water and the ligand in water are run in advance. This is useful the ligand is expected to have a significantly different conformation in solution vs in the complex. The trajectory of this complex is used to estimate the MMPBSA or MMGBSA depending on the options chosen. A General Born (GB) calculation is recommended as this calculation finishes quickly.
 
-    - The statistics file which includes all information about the frames analysed and average energies. The DELTA G binding is estimated. If negative this is a favourable binding. Note that by default the entropy contribution to binding (unfavourable) is not calculated. A normal mode analysis is needed.
-    - The decomposition file contains a breakdown of each residues contribution to the energy. For example using the default Energy Decomposition Scheme (1) the interaction of each residue with the rest of the system is calculated and listed.
-    - The parameter file contains the input parameters passed from Galaxy to MMPBSA.py in the expected MMPBSA input format.
+.. class:: infomark
 
-    .. class:: infomark
+**Outputs created**
 
-    **User guide and documentation**
+- The statistics file which includes all information about the frames analysed and average energies. The DELTA G binding is estimated. If negative this is a favourable binding. Note that by default the entropy contribution to binding (unfavourable) is not calculated. A normal mode analysis is needed.
+- The decomposition file contains a breakdown of each residues contribution to the energy. For example using the default Energy Decomposition Scheme (1) the interaction of each residue with the rest of the system is calculated and listed.
+- The parameter file contains the input parameters passed from Galaxy to MMPBSA.py in the expected MMPBSA input format.
 
-    - The `AmberTools Manual`_
-    - The `Amber Tutorial`_ on using MMPBSA.py
-    - There are many more complex flags available. This Galaxy wrapper only supports GB and PB binding free energies and decomposition. Parallel calculations are not supported at present.
-    - This Galaxy tool is based on MMPBSA.py. More details on options that are not details in the Manual and Tutorials can be found in the code - see "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/input_parser.py" and "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/main.py".
+.. class:: infomark
 
-    .. class:: infomark
+**User guide and documentation**
 
-    **Test data**
+- The `AmberTools Manual`_
+- The `Amber Tutorial`_ on using MMPBSA.py
+- There are many more complex flags available. This Galaxy wrapper only supports GB and PB binding free energies and decomposition. Parallel calculations are not supported at present.
+- This Galaxy tool is based on MMPBSA.py. More details on options that are not details in the Manual and Tutorials can be found in the code - see "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/input_parser.py" and "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/main.py".
 
-    - The test data for this tool comes from an `Amber Tutorial`_ and the original dataset_ is available.
-    - For convenience, water has been stripped from the .mdcrd trajectory and this has been converted to netcdf format.
+.. class:: infomark
 
-    .. code-block:: python
+**Test data**
 
-      import mdtraj as md
-      traj = md.load('1err_prod.mdcrd', top='1err.solvated.prmtop')
-      topology = traj.topology
-      atoms_to_keep = topology.select('not water')
-      traj.restrict_atoms(atoms_to_keep)
-      traj.save('1err_desolvated.nc')
-      traj[0:2].save('1err_desolvated_mini.nc')
+- The test data for this tool comes from an `Amber Tutorial`_ and the original dataset_ is available.
+- For convenience, water has been stripped from the .mdcrd trajectory and this has been converted to netcdf format.
 
+.. code-block:: python
 
-    .. _`Amber Tutorial`: http://ambermd.org/tutorials/advanced/tutorial3/py_script/index.htm
-    .. _`AmberTools Manual`: https://ambermd.org/doc12/Amber18.pdf
-    .. _dataset: http://ambermd.org/tutorials/advanced/tutorial3/py_script/files/Est_Rec_top_mdcrd.tgz
+  import mdtraj as md
+  traj = md.load('1err_prod.mdcrd', top='1err.solvated.prmtop')
+  topology = traj.topology
+  atoms_to_keep = topology.select('not water')
+  traj.restrict_atoms(atoms_to_keep)
+  traj.save('1err_desolvated.nc')
+  traj[0:2].save('1err_desolvated_mini.nc')
 
 
-    ]]>
-  </help>
-  <expand macro="citations">
-    <expand macro="mmpbsa_citation"/>
-  </expand>
+.. _`Amber Tutorial`: http://ambermd.org/tutorials/advanced/tutorial3/py_script/index.htm
+.. _`AmberTools Manual`: https://ambermd.org/doc12/Amber18.pdf
+.. _dataset: http://ambermd.org/tutorials/advanced/tutorial3/py_script/files/Est_Rec_top_mdcrd.tgz
+
+    ]]></help>
+    <expand macro="citations">
+        <expand macro="mmpbsa_citation"/>
+    </expand>
 </tool>

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -45,7 +45,7 @@ with open("$parameteroutfile",'w+') as f:
     <inputs>
         <section name="input" title="Input" expanded="true">
             <conditional name="simulation">
-                <param name="simtype" type="select" label="Single or Multiple Trajectories" help="For a single complex in water choose Single. For complex, receptor and ligand trajectories choose multiple">
+                <param name="simtype" type="select" label="Single or Multiple Trajectories" help="For analysis of a single complex in water choose Single. For separate complex, receptor and ligand trajectories choose Multiple.">
                     <option selected="True" value="single">Single Trajectory Protocol (STP)</option>
                     <option value="multiple">Multiple Trajectory Protocol (MTP)</option>
                 </param>
@@ -60,63 +60,65 @@ with open("$parameteroutfile",'w+') as f:
                     <param format="txt" name="ligand" type="data" label="AMBER prmtop input for Ligand"/>
                     <param format="txt" name="receptor" type="data" label="AMBER prmtop input for Receptor"/>
                     <param format="txt" name="complex" type="data" label="AMBER prmtop input for Complex"/>
-                    <param format="txt" optional="true" name="solvatedcomplex" type="data" label="AMBER prmtop input for Solvated Complex" help="This is optional. Not required if trajectory alraeady has solvent removed"/>
+                    <param format="txt" optional="true" name="solvatedcomplex" type="data" label="AMBER prmtop input for Solvated Complex" help="This is optional. Not required if trajectory already has solvent removed"/>
                     <param format="netcdf" name="trajligand" type="data" label="NetCDF trajectory input for Ligand"/>
                     <param format="netcdf" name="trajreceptor" type="data" label="NetCDF trajectory input for Receptor"/>
                     <param format="netcdf" name="trajcomplex" type="data" label="NetCDF trajectory input for Complex"/>
                 </when>
             </conditional>
         </section>
-        <section name="allparams" title="General parameters" expanded="false">
+        <section name="allparams" title="General parameters" expanded="true">
             <param name="startframe" type="integer" value="1" label="First frame to analyse" min="1" max="100000000"/>
             <param name="endframe" type="integer" value="9999999" label="Final frame to analyse" min="1" max="100000000"/>
-            <param name="interval" type="integer" value="1" label="interval between frames analysed" min="1" max="10000"/>
-            <param name="entropy" type="boolean" checked="true" truevalue="1" falsevalue="0" label="quasi-harmonic entropy calculation" help="Calculate the quasi-harmonic entropy"/>
-            <param name="use_sander" type="boolean" checked="false" label="use sander" truevalue="1" falsevalue="0" help="Forces MMPBSA.py to use sander for energy calculations, even when mmpbsa_py_energy will suffice."/>
-            <param name="verbose" type="integer" value="2" label="verbosity" min="0" max="3" help="0 - not verbose 3 - ultra verbose"/>
-            <param name="keep_files" type="boolean" checked="false" truevalue="1" falsevalue="0" label="keep additional files" help="defaults to false, no extra files kept"/>
-            <param name="strip_mask" type="text" value=":WAT:Cl-:Na+" label="Strip mask" help="Enter a mask for removing unneeded atoms (water/ions)from the solvated prmtop"/>
+            <param name="interval" type="integer" value="1" label="Interval between frames analyzed" min="1" max="10000"/>
+            <param name="entropy" type="boolean" checked="true" truevalue="1" falsevalue="0" label="Perform quasi-harmonic entropy calculation?" help="Calculate the quasi-harmonic entropy"/>
+            <param name="use_sander" type="boolean" checked="false" label="Use sander" truevalue="1" falsevalue="0" help="Forces MMPBSA.py to use sander for energy calculations, even when mmpbsa_py_energy will suffice."/>
+            <param name="keep_files" type="boolean" checked="false" truevalue="1" falsevalue="0" label="Keep additional files?" help="If specified, temporary files will be kept and stored in a collection, which may be helpful for debugging."/>
+            <param name="strip_mask" type="text" value=":WAT:Cl-:Na+" label="Strip mask" help="Enter a mask for removing unneeded atoms (water and ions) from the solvated prmtop file"/>
         </section>
         <section name="calcdetails" title="Details of calculation and parameters" expanded="true">
-            <conditional name="gbcalc">
-                <param name="calctype" type="select" label="General Born calculation" help="Choose carry out General Born Calculation">
-                    <option selected="True" value="yes">yes</option>
-                    <option value="no">no</option>
+            <conditional name="gb_pb_calc">
+                <param name="calctype" type="select" label="GB or PB calculation?" help="Calculate the electrostatic contribution to the free energy with the Poisson-Boltzmann equation or the General Born approximation">
+                    <option selected="True" value="gb">General Born (GB)</option>
+                    <option value="pb">Poisson-Boltzmann (PB)</option>
                 </param>
-                <when value="yes">
-                    <param name="igb" type="select" value="5" label="Generalized GB model to use" min="0" max="7" help="5 - default">
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="5">5</option>
-                        <option value="7">7</option>
-                        <option value="8">8</option>
+                <when value="gb">
+                    <param name="igb" type="select" value="5" label="GB model to use (igb)" help="5 options are available. Consult the AmberTools manual for more details. Note that some missing values (e.g. 3 and 4) are no longer supported.">
+                        <option value="0">0 - no generalized Born term is used</option>
+                        <option value="1">1 - Basic pairwise generalized Born model</option>
+                        <option value="2">2 - OBC model</option>
+                        <option value="5">5 - alternative OBC model</option>
+                        <option value="7">7 - GBn model</option>
+                        <option value="8">8 - alternative GBn model</option>
                     </param>
-                    <param name="saltcon" type="float" value="0" label="Salt Concentration (M)" min="0.0" max="6.0"/>
+                    <param name="saltcon" type="float" value="0" label="Salt concentration (M)" min="0.0" max="6.0"/>
                 </when>
-                <when value="no"/>
-            </conditional>
-            <conditional name="pbcalc">
-                <param name="calctype" type="select" label="Poisson Boltzman calculation" help="Choose carry out Poisson Boltzman Calculation">
-                    <option value="yes">yes</option>
-                    <option selected="True" value="no">no</option>
-                </param>
-                <when value="yes">
-                    <param name="istrng" type="float" value="0.15" label="Ionic Strength (M)" min="0.0" max="2.0"/>
+                <when value="pb">
+                    <param name="istrng" type="float" value="0.15" label="Ionic strength (M)" min="0.0" max="2.0"/>
                     <param name="fillratio" type="float" value="4.0" label="Fill ratio" help="The ratio between the longest dimension of the rectangular finite-difference grid and that of the solute" min="0.0" max="10.0"/>
                     <param name="inp" type="integer" value="1" label="Nonpolar solvation method" min="1" max="2" help="1 - default"/>
                     <param name="radiopt" type="integer" value="0" label="Use optimized radii?" min="0" max="2" help="0 - default do not use these"/>
                 </when>
-                <when value="no"/>
             </conditional>
             <conditional name="decomposition">
-                <param name="decomposition" type="select" label="Decomposition Analysis" help="Choose to carry out decomposition analysis">
+                <param name="decomposition" type="select" label="Carry out decomposition analysis?" help="Choose to carry out decomposition analysis">
                     <option selected="True" value="yes">yes</option>
                     <option value="no">no</option>
                 </param>
                 <when value="yes">
-                    <param name="csv_format" type="boolean" checked="true" truevalue="1" falsevalue="0" label="CSV format" help="Defaults to true, CSV format. Choose false for unformatted text output"/>
-                    <param name="dec_verbose" type="integer" value="1" label="Decomposition Verbosity" min="0" max="2" help="choose how verbose the output is. 0 - not verbose, 2- very verbose"/>
-                    <param name="idecomp" type="integer" value="1" label="Energy Decomposition Scheme" min="1" max="4" help="choose an energy decomposition scheme. 1 - 2 - 3 - 4"/>
+                    <param name="csv_format" type="boolean" checked="true" truevalue="1" falsevalue="0" label="CSV format" help="Output in CSV format; choose false for unformatted text output"/>
+                    <param name="dec_verbose" type="select" value="0" label="Decomposition verbosity" help="Choose verbosity of the decomposition output file. Note that if the verbosity level selected is too high and the parser cannot find the requested information, the job will fail.">
+                        <option value="0">DELTA energy, total contribution only</option>
+                        <option value="1">DELTA energy, total, sidechain, and backbone contributions</option>
+                        <option value="2">Complex, Receptor, Ligand, and DELTA energies, total contribution only</option>
+                        <option value="3">Complex, Receptor, Ligand, and DELTA energies, total, sidechain, and backbone contributions</option>
+                    </param>
+                    <param name="idecomp" type="select" value="1" label="Energy decomposition scheme to use" help="Choose an energy decomposition scheme.">
+                        <option value="1">Per-residue decomp with 1-4 terms added to internal potential terms</option>
+                        <option value="2">Per-residue decomp with 1-4 EEL added to EEL and 1-4 VDW added to VDW potential terms.</option>
+                        <option value="3">Pairwise decomp with 1-4 terms added to internal potential terms</option>
+                        <option value="4">Pairwise decomp with 1-4 EEL added to EEL and 1-4 VDW added to VDW potential terms</option>
+                    </param>
                 </when>
                 <when value="no"/>
             </conditional>
@@ -124,8 +126,14 @@ with open("$parameteroutfile",'w+') as f:
     </inputs>
     <outputs>
         <data format="txt" name="resultoutfile" label="${tool.name}: Statistics"/>
-        <data format="txt" name="decompoutfile" label="${tool.name}: Decomposition Statistics"/>
-        <data format="txt" name="parameteroutfile" label="${tool.name}: parameter output"/>
+        <data format="txt" name="decompoutfile" label="${tool.name}: Decomposition statistics">
+            <filter>calcdetails['decomposition']['decomposition'] == 'yes'</filter>
+        </data>
+        <data format="txt" name="parameteroutfile" label="${tool.name}: Parameter output"/>
+        <collection name="tempfiles" type="list" label="${tool.name}: Temporary files">
+            <filter>allparams['keep_files'] == 1</filter>
+            <discover_datasets pattern="_MMPBSA(?P&lt;designation&gt;.+)" format="txt"/>
+        </collection>
     </outputs>
     <tests>
         <test>
@@ -135,13 +143,14 @@ with open("$parameteroutfile",'w+') as f:
             <param name="trajcomplex" value="1err_desolvated_mini.nc" ftype="netcdf"/>
             <conditional name="allparams">
                 <param name="entropy" value="false"/>
+                <param name="keep_files" value="true"/>
             </conditional>
-            <conditional name="gbcalc">
-                <param name="calctype" value="yes"/>
+            <conditional name="gb_pb_calc">
+                <param name="calctype" value="gb"/>
                 <param name="igb" value="2"/>
                 <param name="saltcon" value="0.100"/>
             </conditional>
-            <conditional name="decomposition">
+            <conditional name="">
                 <param name="decomposition" value="no"/>
             </conditional>
             <output name="resultoutfile">
@@ -196,24 +205,27 @@ with open("$parameteroutfile",'w+') as f:
 
 **What it does**
 
-This tool calculates the Molecular Mechanics Poisson-Boltzman Surface Area (MMPBSA) which is an estimate of the binding free energy between a ligand and a receptor.
+This tool calculates the Molecular Mechanics Poisson-Boltzman Surface Area (MMPBSA), which is an estimate of the binding free energy between a ligand and a receptor. It also can calculate the MMGBSA, which is a common alternative, replacing the Poisson-Boltzmann term with the General Born approximation.
 
 .. class:: infomark
 
 **How it works**
 
-Prior to using this tool simulations of the ligand complexed with the receptor must be run. This tool, which wraps AmberTools will need a prmtop (Amber style parameter topology file for the receptor, ligand and the complex) and the trajectory in netCDF format.
+Prior to using this tool, simulations of the ligand complexed with the receptor must be run. This tool, which wraps AmberTools, requires a prmtop (Amber parameter topology) file for the receptor, ligand and the complex and the trajectory in netCDF format.
 
-- Single Trajectory Estimate: A simulation of the complex in water is run in advance. The trajectory of this complex is used to estimate the MMPBSA or MMGBSA depending on the options chosen. A General Born (GB) calculation is recommended as this calculation finishes quickly.
-- Multiple Trajectory Estimate: A simulation of the complex in water, the receptor in water and the ligand in water are run in advance. This is useful the ligand is expected to have a significantly different conformation in solution vs in the complex. The trajectory of this complex is used to estimate the MMPBSA or MMGBSA depending on the options chosen. A General Born (GB) calculation is recommended as this calculation finishes quickly.
+- Single Trajectory Estimate: A single simulation of the complex in water is run. The trajectory of this complex is used to estimate the MMPBSA or MMGBSA, depending on the options chosen.
+- Multiple Trajectory Estimate: Separate simulations of the complex in water, the receptor in water and the ligand in water are run. This is useful if the ligand (or receptor) is expected to have a significantly different conformation in solution compared to in the complex, but is otherwise not recommended as it increases the uncertainty of the results. The trajectories are used to estimate the MMPBSA or MMGBSA depending on the options chosen.
+
+If simulations were performed using the Galaxy GROMACS tools, the topology (in top format) and trajectories (in xtc format) can be converted to Amber prmtop and netcdf formats using the Convert Parameters and MDTraj file converter tools respectively.
 
 .. class:: infomark
 
 **Outputs created**
 
 - The statistics file which includes all information about the frames analysed and average energies. The DELTA G binding is estimated. If negative this is a favourable binding. Note that by default the entropy contribution to binding (unfavourable) is not calculated. A normal mode analysis is needed.
-- The decomposition file contains a breakdown of each residues contribution to the energy. For example using the default Energy Decomposition Scheme (1) the interaction of each residue with the rest of the system is calculated and listed.
 - The parameter file contains the input parameters passed from Galaxy to MMPBSA.py in the expected MMPBSA input format.
+- (Optional, if decomposition analysis is performed) The decomposition file contains a breakdown of each residue's contribution to the energy. For example, using the default energy decomposition scheme (1) the interaction of each residue with the rest of the system is calculated and listed.
+- (Optional, if the "Keep additional files?" option is chosen) A collection containing all temporary files generated in the course of the calculation. This may be useful for debugging.
 
 .. class:: infomark
 
@@ -222,7 +234,7 @@ Prior to using this tool simulations of the ligand complexed with the receptor m
 - The `AmberTools Manual`_
 - The `Amber Tutorial`_ on using MMPBSA.py
 - There are many more complex flags available. This Galaxy wrapper only supports GB and PB binding free energies and decomposition. Parallel calculations are not supported at present.
-- This Galaxy tool is based on MMPBSA.py. More details on options that are not details in the Manual and Tutorials can be found in the code - see "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/input_parser.py" and "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/main.py".
+- This Galaxy tool is based on MMPBSA.py. More details on options that are not described in the Manual and Tutorials can be found in the code - see "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/input_parser.py" and "$CONDA_PREFIX/lib/python3.7/site-packages/MMPBSA_mods/main.py".
 
 .. class:: infomark
 

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -6,7 +6,7 @@
   </macros>
   <expand macro="requirements">
     <requirement type="package" version="3.2.0">parmed</requirement>
-    <requirement type="package" version="2020.2">gromacs</requirement>
+    <requirement type="package" version="2020.4">gromacs</requirement>
     <requirement type="package" version="2.11.2">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">

--- a/tools/buildtools/ambertools/template_mmpbsa_mmgbsa.j2
+++ b/tools/buildtools/ambertools/template_mmpbsa_mmgbsa.j2
@@ -2,15 +2,15 @@
 #  
 &general
 startframe={{ allparams.startframe }}, endframe={{ allparams.endframe }}, interval={{ allparams.interval }},
-verbose=2, keep_files={{ allparams.keep_files | int }}, strip_mask={{ allparams.strip_mask }}, use_sander={{ allparams.use_sander | int }}, entropy={{ allparams.entropy | int }},  netcdf=1
+verbose=2, keep_files={{ allparams.keep_files | int }}, strip_mask={{ allparams.strip_mask }}, use_sander={{ allparams.use_sander | int }}, entropy={{ allparams.entropy | int }}, netcdf=1
 /
 {% if calcdetails.gb_pb_calc.calctype == 'gb' %}
 &gb
-igb={{ calcdetails.gb_pb_calc.igb }}, saltcon={{ calcdetails.gb_pb_calc.saltcon }}
+igb={{ calcdetails.gb_pb_calc.igb }}, saltcon={{ calcdetails.gb_pb_calc.saltcon }}, surfoff={{ calcdetails.gb_pb_calc.surfoff }}, molsurf={{ calcdetails.gb_pb_calc.molsurf | int}}, probe={{ calcdetails.gb_pb_calc.probe }}, msoffset={{ calcdetails.gb_pb_calc.msoffset }}
 /
 {% elif calcdetails.gb_pb_calc.calctype == 'pb' %}
 &pb
-istrng={{ calcdetails.gb_pb_calc.istrng }}, fillratio={{ calcdetails.gb_pb_calc.fillratio }}, inp={{ calcdetails.gb_pb_calc.inp }},radiopt={{ calcdetails.gb_pb_calc.radiopt }}
+istrng={{ calcdetails.gb_pb_calc.istrng }}, fillratio={{ calcdetails.gb_pb_calc.fillratio }}, inp={{ calcdetails.gb_pb_calc.inp }}, radiopt={{ calcdetails.gb_pb_calc.radiopt }}, cavity_offset={{ calcdetails.gb_pb_calc.cavity_offset }}, exdi={{ calcdetails.gb_pb_calc.exdi }}, indi={{ calcdetails.gb_pb_calc.indi }}, scale={{ calcdetails.gb_pb_calc.scale }}, linit={{ calcdetails.gb_pb_calc.linit }}, prbrad={{ calcdetails.gb_pb_calc.prbrad }}
 /
 {% endif %}
 {% if calcdetails.decomposition.decomposition == 'yes' %}

--- a/tools/buildtools/ambertools/template_mmpbsa_mmgbsa.j2
+++ b/tools/buildtools/ambertools/template_mmpbsa_mmgbsa.j2
@@ -2,16 +2,15 @@
 #  
 &general
 startframe={{ allparams.startframe }}, endframe={{ allparams.endframe }}, interval={{ allparams.interval }},
-verbose={{ allparams.verbose }}, keep_files={{ allparams.keep_files | int }}, strip_mask={{ allparams.strip_mask }}, use_sander={{ allparams.use_sander | int }}, entropy={{ allparams.entropy | int }},  netcdf=1
+verbose=2, keep_files={{ allparams.keep_files | int }}, strip_mask={{ allparams.strip_mask }}, use_sander={{ allparams.use_sander | int }}, entropy={{ allparams.entropy | int }},  netcdf=1
 /
-{% if calcdetails.gbcalc.calctype == 'yes' %}
+{% if calcdetails.gb_pb_calc.calctype == 'gb' %}
 &gb
-igb={{ calcdetails.gbcalc.igb }}, saltcon={{ calcdetails.gbcalc.saltcon }}
+igb={{ calcdetails.gb_pb_calc.igb }}, saltcon={{ calcdetails.gb_pb_calc.saltcon }}
 /
-{% endif %}
-{% if calcdetails.pbcalc.calctype == 'yes' %}
+{% elif calcdetails.gb_pb_calc.calctype == 'pb' %}
 &pb
-istrng={{ calcdetails.pbcalc.istrng }}, fillratio={{ calcdetails.pbcalc.fillratio }}, inp={{ calcdetails.pbcalc.inp }},radiopt={{ calcdetails.pbcalc.radiopt }}
+istrng={{ calcdetails.gb_pb_calc.istrng }}, fillratio={{ calcdetails.gb_pb_calc.fillratio }}, inp={{ calcdetails.gb_pb_calc.inp }},radiopt={{ calcdetails.gb_pb_calc.radiopt }}
 /
 {% endif %}
 {% if calcdetails.decomposition.decomposition == 'yes' %}

--- a/tools/buildtools/ambertools/template_mmpbsa_mmgbsa.j2
+++ b/tools/buildtools/ambertools/template_mmpbsa_mmgbsa.j2
@@ -10,7 +10,7 @@ igb={{ calcdetails.gb_pb_calc.igb }}, saltcon={{ calcdetails.gb_pb_calc.saltcon 
 /
 {% elif calcdetails.gb_pb_calc.calctype == 'pb' %}
 &pb
-istrng={{ calcdetails.gb_pb_calc.istrng }}, fillratio={{ calcdetails.gb_pb_calc.fillratio }}, inp={{ calcdetails.gb_pb_calc.inp }}, radiopt={{ calcdetails.gb_pb_calc.radiopt }}, cavity_offset={{ calcdetails.gb_pb_calc.cavity_offset }}, exdi={{ calcdetails.gb_pb_calc.exdi }}, indi={{ calcdetails.gb_pb_calc.indi }}, scale={{ calcdetails.gb_pb_calc.scale }}, linit={{ calcdetails.gb_pb_calc.linit }}, prbrad={{ calcdetails.gb_pb_calc.prbrad }}
+istrng={{ calcdetails.gb_pb_calc.istrng }}, fillratio={{ calcdetails.gb_pb_calc.fillratio }}, inp={{ calcdetails.gb_pb_calc.inp }}, radiopt={{ calcdetails.gb_pb_calc.radiopt }}, cavity_offset={{ calcdetails.gb_pb_calc.cavity_offset }}, scale={{ calcdetails.gb_pb_calc.scale }}, linit={{ calcdetails.gb_pb_calc.linit }}, prbrad={{ calcdetails.gb_pb_calc.prbrad }}
 /
 {% endif %}
 {% if calcdetails.decomposition.decomposition == 'yes' %}

--- a/tools/buildtools/ambertools/template_mmpbsa_mmgbsa.j2
+++ b/tools/buildtools/ambertools/template_mmpbsa_mmgbsa.j2
@@ -2,7 +2,7 @@
 #  
 &general
 startframe={{ allparams.startframe }}, endframe={{ allparams.endframe }}, interval={{ allparams.interval }},
-verbose={{ allparams.verbose }}, keep_files={{ allparams.keep_files | int }}, strip_mask={{ allparams.strip_mask }}, use_sander={{ allparams.use_sander | int }}, entropy={{ allparams.entropy | int }}
+verbose={{ allparams.verbose }}, keep_files={{ allparams.keep_files | int }}, strip_mask={{ allparams.strip_mask }}, use_sander={{ allparams.use_sander | int }}, entropy={{ allparams.entropy | int }},  netcdf=1
 /
 {% if calcdetails.gbcalc.calctype == 'yes' %}
 &gb


### PR DESCRIPTION
Updating the MM(GB/PB)SA tool as I would like to use it for the covid project:

- Add some more options to the tool
- Ensure some outputs (decomposition output, temp files) are optionally returned with filter
- Ensure exactly one of GB and PB has to be selected and not both or neither

Also updated tool versions for all the AmberTools tools.