### PR TITLE
Workaround to output xvg file

### DIFF
--- a/tools/gromacs/sim.xml
+++ b/tools/gromacs/sim.xml
@@ -2,7 +2,7 @@
     <description>for system equilibration or data collection</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@GALAXY_VERSION@">0</token>
+        <token name="@GALAXY_VERSION@">1</token>
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
@@ -255,11 +255,14 @@
         <data name="output7" format="xvg" from_work_dir="outp_pullf.xvg">
             <filter>outps["xvg_out"] == 'true'</filter>
         </data>
+        <data name="output8" format="xvg" from_work_dir="outp.xvg">
+            <filter>outps["xvg_out"] == 'true'</filter>
+        </data>
         <!-- <collection name="output7" type="list">
             <discover_datasets pattern="(?P&lt;designation&gt;.*)\.xvg" visible="true" directory="." />
             <filter>outps["xvg_out"] == 'true'</filter>
         </collection> -->
-        <data name="output8" format="binary" from_work_dir="outp.tpr">
+        <data name="output9" format="binary" from_work_dir="outp.tpr">
             <filter>outps["tpr_out"] == 'true'</filter>
         </data>
 


### PR DESCRIPTION
Temporary fix until xvg collection can be created. Additional output created (output 8) to output outp.xvg (filename as set by -deffnm)