### PR TITLE
Updating tools/bio3d from version 2.4_1 to
2.4_4

### DIFF
--- a/tools/bio3d/dccm.xml
+++ b/tools/bio3d/dccm.xml
@@ -99,7 +99,7 @@
             <param name="sele" value="calpha"/>
             <output name="dccm_plot">
               <assert_contents>
-                <has_size value="280500" delta="20000"/>
+                <has_size value="350000" delta="20000"/>
               </assert_contents>
             </output>
         </test>

--- a/tools/bio3d/dccm.xml
+++ b/tools/bio3d/dccm.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="0.20_38">r-lattice</requirement>
+        <requirement type="package" version="0.20_44">r-lattice</requirement>
     </expand>
     <command detect_errors="exit_code">
 <![CDATA[ 

--- a/tools/bio3d/dccm.xml
+++ b/tools/bio3d/dccm.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="0.20_44">r-lattice</requirement>
+        <requirement type="package" version="0.20.29">r-lattice</requirement>
     </expand>
     <command detect_errors="exit_code">
 <![CDATA[ 

--- a/tools/bio3d/macros.xml
+++ b/tools/bio3d/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.4_3</token>
+    <token name="@TOOL_VERSION@">2.4_4</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">r-bio3d</requirement>

--- a/tools/bio3d/macros.xml
+++ b/tools/bio3d/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.4_1</token>
+    <token name="@TOOL_VERSION@">2.4_2</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">r-bio3d</requirement>

--- a/tools/bio3d/macros.xml
+++ b/tools/bio3d/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.4_2</token>
+    <token name="@TOOL_VERSION@">2.4_3</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">r-bio3d</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/bio3d**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/bio3d from version 2.4_1 to 2.4_2.

**Project home page:** http://thegrantlab.org/bio3d/index.php