### PR TITLE
Updating tools/buildtools/ambertools from version 21.7 to 21.9

### DIFF
--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">21.7</token>
+  <token name="@TOOL_VERSION@">21.9</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -5,8 +5,8 @@
     <token name="@GALAXY_VERSION@">0</token>
   </macros>
   <expand macro="requirements">
-    <requirement type="package" version="3.4.1">parmed</requirement>
-    <requirement type="package" version="2021.1">gromacs</requirement>
+    <requirement type="package" version="3.4.3">parmed</requirement>
+    <requirement type="package" version="2021.3">gromacs</requirement>
     <requirement type="package" version="3.0.1">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/buildtools/ambertools**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/buildtools/ambertools from version 21.7 to 21.9.

**Project home page:** http://ambermd.org/AmberTools.php