### PR TITLE
Updating tools/buildtools/ambertools from version 21.10 to 21.11

### DIFF
--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">21.10</token>
+  <token name="@TOOL_VERSION@">21.11</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="3.0.1">jinja2</requirement>
+        <requirement type="package" version="3.0.2">jinja2</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         python '$mmpbsa_script' '$inputs' &&

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements">
     <requirement type="package" version="3.4.3">parmed</requirement>
     <requirement type="package" version="2021.3">gromacs</requirement>
-    <requirement type="package" version="3.0.1">jinja2</requirement>
+    <requirement type="package" version="3.0.2">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">
     <![CDATA[


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/buildtools/ambertools**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/buildtools/ambertools from version 21.10 to 21.11.

**Project home page:** http://ambermd.org/AmberTools.php

**Maintainers** @chrisbarnettster ,@simonbray