### PR TITLE
Updating tools/buildtools/ambertools from version 21.10 to
23.3

### DIFF
--- a/tools/buildtools/ambertools/acpype.xml
+++ b/tools/buildtools/ambertools/acpype.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="2022.7.21">acpype</requirement>
+        <requirement type="package" version="2023.10.27">acpype</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         ln -s '$input1' ./input1.${input1.ext} &&

--- a/tools/buildtools/ambertools/acpype.xml
+++ b/tools/buildtools/ambertools/acpype.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="2022.1.3">acpype</requirement>
+        <requirement type="package" version="2022.7.21">acpype</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         ln -s '$input1' ./input1.${input1.ext} &&

--- a/tools/buildtools/ambertools/acpype.xml
+++ b/tools/buildtools/ambertools/acpype.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="2021.02.05.22.15">acpype</requirement>
+        <requirement type="package" version="2022.1.3">acpype</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         ln -s '$input1' ./input1.${input1.ext} &&

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">21.10</token>
+  <token name="@TOOL_VERSION@">21.11</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">23.0</token>
+  <token name="@TOOL_VERSION@">23.3</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">22.5</token>
+  <token name="@TOOL_VERSION@">23.0</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">21.12</token>
+  <token name="@TOOL_VERSION@">22.0</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">21.11</token>
+  <token name="@TOOL_VERSION@">21.12</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">23.3</token>
+  <token name="@TOOL_VERSION@">23.6</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">22.0</token>
+  <token name="@TOOL_VERSION@">22.4</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/macros.xml
+++ b/tools/buildtools/ambertools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">22.4</token>
+  <token name="@TOOL_VERSION@">22.5</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ambertools</requirement>

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="3.0.2">jinja2</requirement>
+        <requirement type="package" version="3.0.3">jinja2</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         python '$mmpbsa_script' '$inputs' &&

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="3.1.2">jinja2</requirement>
+        <requirement type="package" version="3.1.3">jinja2</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         python '$mmpbsa_script' '$inputs' &&

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="3.0.1">jinja2</requirement>
+        <requirement type="package" version="3.0.2">jinja2</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         python '$mmpbsa_script' '$inputs' &&

--- a/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
+++ b/tools/buildtools/ambertools/mmpbsa_mmgbsa.xml
@@ -5,7 +5,7 @@
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="3.0.3">jinja2</requirement>
+        <requirement type="package" version="3.1.2">jinja2</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         python '$mmpbsa_script' '$inputs' &&

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -6,8 +6,8 @@
   </macros>
   <expand macro="requirements">
     <requirement type="package" version="3.4.3">parmed</requirement>
-    <requirement type="package" version="2021.3">gromacs</requirement>
-    <requirement type="package" version="3.0.3">jinja2</requirement>
+    <requirement type="package" version="2022.3">gromacs</requirement>
+    <requirement type="package" version="3.1.2">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">
     <![CDATA[

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements">
     <requirement type="package" version="3.4.3">parmed</requirement>
     <requirement type="package" version="2021.3">gromacs</requirement>
-    <requirement type="package" version="3.0.1">jinja2</requirement>
+    <requirement type="package" version="3.0.2">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">
     <![CDATA[

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -5,9 +5,9 @@
     <token name="@GALAXY_VERSION@">0</token>
   </macros>
   <expand macro="requirements">
-    <requirement type="package" version="4.1.0">parmed</requirement>
-    <requirement type="package" version="2023.1">gromacs</requirement>
-    <requirement type="package" version="3.1.2">jinja2</requirement>
+    <requirement type="package" version="4.2.2">parmed</requirement>
+    <requirement type="package" version="2023.4">gromacs</requirement>
+    <requirement type="package" version="3.1.3">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">
     <![CDATA[

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -5,8 +5,8 @@
     <token name="@GALAXY_VERSION@">0</token>
   </macros>
   <expand macro="requirements">
-    <requirement type="package" version="3.4.3">parmed</requirement>
-    <requirement type="package" version="2022.3">gromacs</requirement>
+    <requirement type="package" version="4.1.0">parmed</requirement>
+    <requirement type="package" version="2022.4">gromacs</requirement>
     <requirement type="package" version="3.1.2">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -6,7 +6,7 @@
   </macros>
   <expand macro="requirements">
     <requirement type="package" version="4.1.0">parmed</requirement>
-    <requirement type="package" version="2022.4">gromacs</requirement>
+    <requirement type="package" version="2023.1">gromacs</requirement>
     <requirement type="package" version="3.1.2">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">

--- a/tools/buildtools/ambertools/parmconv.xml
+++ b/tools/buildtools/ambertools/parmconv.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements">
     <requirement type="package" version="3.4.3">parmed</requirement>
     <requirement type="package" version="2021.3">gromacs</requirement>
-    <requirement type="package" version="3.0.2">jinja2</requirement>
+    <requirement type="package" version="3.0.3">jinja2</requirement>
   </expand>
   <command detect_errors="exit_code">
     <![CDATA[


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/buildtools/ambertools**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/buildtools/ambertools from version 21.10 to 21.11.

**Project home page:** http://ambermd.org/AmberTools.php

**Maintainers:** @chrisbarnettster, @simonbray