### PR TITLE
changed the coupling groups in line 102 from (Protein Non-Protein) to (non-Water Water)

### DIFF
--- a/tools/gromacs/sim.xml
+++ b/tools/gromacs/sim.xml
@@ -2,7 +2,7 @@
     <description>for system equilibration or data collection</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@GALAXY_VERSION@">2</token>
+        <token name="@GALAXY_VERSION@">3</token>
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/gromacs/sim.xml
+++ b/tools/gromacs/sim.xml
@@ -99,7 +99,7 @@
                     fourierspacing  = 0.16    ; grid spacing for FFT
                     ; Temperature coupling is on
                     tcoupl    = V-rescale              ; modified Berendsen thermostat
-                    tc-grps    = Protein Non-Protein  ; two coupling groups - more accurate
+                    tc-grps    = non-Water Water  ; two coupling groups - more accurate
                     tau_t    = 0.1    0.1          ; time constant, in ps
                     ref_t    = $sets.mdp.temperature $sets.mdp.temperature           ; reference temperature, one for each group, in K
                     ; Periodic boundary conditions


### PR DESCRIPTION
I'm proposing this change because currently the chosen groups in the .mdp settings of sim.xml (Protein and Non-Protein) will only work for a system with peptides in it. Given the diversity of the chemical systems that can be simulated in GROMACS, and thus the versatility that could be extended to users of galaxy, I recommend changing these groups to "non-Water and Water" in order for the simulations to run across many different chemical species. 

In general, one is trying to thermocouple the system here. This can be achieved by using a single coupling group (System), or if we choose to use two for more accuracy, then what we should be coupling are "solutes and non-solutes". The easiest way to achieve this, using the automatically indexed groups in any water-solvated system, is "non-Water Water". 
