### PR TITLE
modified sim.xml and macros.xml to allow for system thermocoupling and option to start velocities at NVT

### DIFF
--- a/tools/gromacs/macros.xml
+++ b/tools/gromacs/macros.xml
@@ -3,9 +3,9 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">gromacs</requirement>
+        <yield/>   
         </requirements>
     </xml>
-
     <token name="@MAXWARN_CMD@">-maxwarn '$mxw'</token>
 
     <xml name="citations">
@@ -24,6 +24,15 @@
                 <param argument="mdp_input" type="data" format='mdp' label="MD parameters (MDP) file (optional; default settings if not set)"/>
             </when>
             <when value="default">
+                <conditional name="startingvelocities">
+                   <param name="startvel" type="select" label="Starting Velocities">
+                       <option value="true">Assign starting velocities (recommended for NVT)</option>
+                       <option value="false" selected="true">Do not assign starting velocites (recommended for NPT)</option>
+                   </param>
+                     <when value="true"/>
+                     <when value="false"/>
+                </conditional>
+
                 <param argument="integrator" type="select" label="Choice of integrator">
                     <option value="md">A leap-frog algorithm for integrating Newton's equations of motion.</option>
                     <option value="sd">Stochastic dynamics integrator</option>
@@ -47,6 +56,14 @@
                 </param>
                 
                 <param argument="temperature" type="integer" label="Temperature /K" value="0" min="0" max="1000000" help="Temperature" />
+                <conditional name="couplinggroups">
+                   <param name="wholesystem" type="select" label="Number of groups to set for thermocoupling">
+                       <option value="true">Single coupling group (System)</option>
+                       <option value="false" selected="true">Two coupling groups (Protein and Non-Protein)</option>
+                   </param>
+                     <when value="true"/>
+                     <when value="false"/>
+                </conditional>
                 <param argument="step_length" type="float" label="Step length in ps" value="0" min="0.0001" max="1.0" help="Step length in ps." />
                 <param argument="write_freq" type="integer" label="Number of steps that elapse between saving data points (velocities, forces, energies)" value="0" min="0" max="1000000" help="Step length in ps." />
                 <param argument="rcoulomb" value="1.0" type="float" label="Distance for the Coulomb cut-off."/>
@@ -67,6 +84,7 @@
     <xml name="maxwarn">
         <param name="mxw" value="0" min="0" argument="-maxwarn" type="integer" label="Maximum warnings to allow." help="Do not use this unless you know what you are doing. This option allows you to override non-fatal warnings, that would otherwise cause the simulation to fail."/>
     </xml>
+
 
     <xml name="log_outputs">
         <data name="report" format="txt" from_work_dir="verbose.txt" label="GROMACS log file on ${on_string}">

--- a/tools/gromacs/sim.xml
+++ b/tools/gromacs/sim.xml
@@ -2,7 +2,7 @@
     <description>for system equilibration or data collection</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@GALAXY_VERSION@">2</token>
+        <token name="@GALAXY_VERSION@">3</token>
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
@@ -98,16 +98,28 @@
                     pme_order      = 4        ; cubic interpolation
                     fourierspacing  = 0.16    ; grid spacing for FFT
                     ; Temperature coupling is on
+                    #if $sets.mdp.couplinggroups.wholesystem =="true":
+                    tcouple   = V-recale ; modified Berendsen thermostat
+                    tc-grps = System ; coupling the whole system. Can be used in any system, beyond peptides. 
+                    tau_t    = 0.1 ; time constant in ps
+                    ref_t    = $sets.mdp.temperature
+                    #else
                     tcoupl    = V-rescale              ; modified Berendsen thermostat
-                    tc-grps    = Protein Non-Protein  ; two coupling groups - more accurate
+                    tc-grps   = Protein Non-Protein  ; two coupling groups - more accurate
                     tau_t    = 0.1    0.1          ; time constant, in ps
                     ref_t    = $sets.mdp.temperature $sets.mdp.temperature           ; reference temperature, one for each group, in K
+                    #end if
                     ; Periodic boundary conditions
                     pbc    = xyz    ; 3-D PBC
                     ; Dispersion correction
                     DispCorr  = EnerPres  ; account for cut-off vdW scheme
+                    #if $sets.ensemble =="nvt" and $sets.mdp.startingvelocities.startvel =="true":
                     ; Velocity generation
-                    gen_vel    = no    ; Velocity generation is off
+                    gen_vel    = yes    ; Velocity generation is ON
+                    #else
+                    ; Velocity generation
+                    gen_vel    = no    ; Velocity generation is OFF
+                    #end if
                 #end if
                 #if $inps.itp_in:
                     define    = -DPOSRES  ; position restrain the protein
@@ -130,7 +142,7 @@
     <inputs>
         <param argument="gro_input" type="data" format='gro' label="GRO structure file"/>
         <param argument="top_input" type="data" format='top' label="Topology (TOP) file"/>
-
+ 
         <section name="inps" title="Inputs" expanded="false">
         
             <!-- CPT inp -->
@@ -174,6 +186,7 @@
             </conditional> -->
 
             <param argument="ndx_in" type="data" format='ndx' label="Index (ndx) file" optional="true" help="Use an index file specifying custom atom groups. Leave empty to use default generated group"/>
+            
 
         </section>
 
@@ -226,7 +239,6 @@
                 <option value="nvt">Isothermal-isochoric ensemble (NVT)</option>
                 <option value="npt">Isothermal-isobaric ensemble (NPT)</option>
             </param>
-
             <expand macro="md_inputs"/>
         </section>
         


### PR DESCRIPTION
Now being able to choose to couple the entire system, users will no longer be limited to simulations of peptides. Before this, the default option was a dual coupling setup where it was set to "Protein Non-Protein". This would cause a failure any time someone simulated non-peptide systems. The new option to couple the whole system will allow users to virtually use any .gro file. Changes were made to both the sim.xml file and the macros.xml file. 

Additionally, the option was added to add starting velocities in an NVT simulation. I made it an option via conditionals for this rather than having it hard coded, even though, in practice one should always assign starting velocities at NVT (the system needs to start with some kinetic energy). Cheers!