### PR TITLE
Updating tools/mdfileconverter from version 1.9.6 to 1.9.7

### DIFF
--- a/tools/mdfileconverter/md_converter.xml
+++ b/tools/mdfileconverter/md_converter.xml
@@ -1,7 +1,7 @@
 <tool id="md_converter" name="MDTraj file converter" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <description>- interconvert between MD trajectory file formats.</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.9.6</token>
+        <token name="@TOOL_VERSION@">1.9.7</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/mdfileconverter**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/mdfileconverter from version 1.9.6 to 1.9.7.

**Maintainers:** @chrisbarnettster, @tsenapathi