### PR TITLE
Updating tools/mdslicer from version 1.9.6 to 1.9.7

### DIFF
--- a/tools/mdslicer/md_slicer.xml
+++ b/tools/mdslicer/md_slicer.xml
@@ -1,7 +1,7 @@
 <tool id="md_slicer" name="Slice MD trajectories" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <description>using the MDTraj package</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.9.6</token>
+        <token name="@TOOL_VERSION@">1.9.7</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/mdslicer**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/mdslicer from version 1.9.6 to 1.9.7.

**Maintainers:** @chrisbarnettster, @tsenapathi