### PR TITLE
Updating tools/mdtraj from version 1.9.6 to 1.9.7

### DIFF
--- a/tools/mdtraj/macros.xml
+++ b/tools/mdtraj/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.9.6</token>
+    <token name="@TOOL_VERSION@">1.9.7</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">mdtraj</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/mdtraj**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/mdtraj from version 1.9.6 to 1.9.7.

**Project home page:** https://github.com/mdtraj/mdtraj/releases

**Maintainers:** @chrisbarnettster, @tsenapathi, @simonbray