### PR TITLE
Updating tools/gromacs from version 2021.3 to 2022

### DIFF
--- a/tools/gromacs/energy.xml
+++ b/tools/gromacs/energy.xml
@@ -1,7 +1,7 @@
 <tool id="gmx_energy" name="Extract energy components with GROMACS" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <macros>
         <import>macros.xml</import>
-        <token name="@GALAXY_VERSION@">1</token>
+        <token name="@GALAXY_VERSION@">0</token>
     </macros>
 
     <expand macro="requirements" />

--- a/tools/gromacs/macros.xml
+++ b/tools/gromacs/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2021.3</token>
+    <token name="@TOOL_VERSION@">2022</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">gromacs</requirement>

--- a/tools/gromacs/minim.xml
+++ b/tools/gromacs/minim.xml
@@ -2,7 +2,7 @@
     <description>of the system prior to equilibration and production MD</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@GALAXY_VERSION@">1</token>
+        <token name="@GALAXY_VERSION@">0</token>
     </macros>
 
     <expand macro="requirements" />

--- a/tools/gromacs/sim.xml
+++ b/tools/gromacs/sim.xml
@@ -318,7 +318,7 @@
             </output>
             <output name="output8" ftype="tpr">
                 <assert_contents>
-                    <has_size value="44212" />
+                    <has_size value="44400" />
                 </assert_contents>
             </output>
         </test>

--- a/tools/gromacs/sim.xml
+++ b/tools/gromacs/sim.xml
@@ -2,7 +2,7 @@
     <description>for system equilibration or data collection</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@GALAXY_VERSION@">3</token>
+        <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/gromacs/solvate.xml
+++ b/tools/gromacs/solvate.xml
@@ -2,7 +2,7 @@
     <description>to structure and topology files</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@GALAXY_VERSION@">1</token>
+        <token name="@GALAXY_VERSION@">0</token>
     </macros>
 
     <expand macro="requirements" />


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/gromacs**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/gromacs from version 2021.3 to 2022.

**Project home page:** https://github.com/gromacs/releases

**Maintainers:** @simonbray