### PR TITLE
Fix bug ordering trajectory inputs in trjcat tool

### DIFF
--- a/tools/gromacs/trj.xml
+++ b/tools/gromacs/trj.xml
@@ -140,7 +140,7 @@
                 </conditional>
             </when>
             <when value="trjcat">
-                <param name="trj_input" type="data" format='xtc,trr' label="Input trajectories" help="In XTC or TRR format, but please do not mix the two. Please note this tool does not currently take order into account when concatenating." multiple="true"/>
+                <param name="trj_input" type="data" format='xtc,trr' label="Input trajectories" help="In XTC or TRR format, but please do not mix the two. Please note that if you want to take order into account when concatenating, you must use a collection as input." multiple="true"/>
                 <param name="cat" type="boolean" label="Do not discard double time frames" truevalue="-cat" falsevalue="-nocat"/>
                 <param name="sep" type="hidden" value="" />
             </when>

--- a/tools/gromacs/trj.xml
+++ b/tools/gromacs/trj.xml
@@ -2,7 +2,7 @@
     <description>using trjconv and trjcat</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@GALAXY_VERSION@">0</token>
+        <token name="@GALAXY_VERSION@">1</token>
         <xml name="fit_when" token_option="none">
             <when value="@OPTION@">
                 <param name="index_fit" type="text" label="Index of group to use for fitting" help="Index of group to use for fitting - i.e. the group's position in the ndx file (using zero-based numbering, so the first group has index 0).">
@@ -18,7 +18,7 @@
     #if $trj.trj_op == 'trjcat':
         mkdir trajs &&
         #for $value, $file in enumerate($trj_input):
-            ln -s '$file' trajs/traj_${value}.${file.ext} &&
+            ln -s '$file' trajs/traj_${str(value).rjust(10, '0')}.${file.ext} &&
         #end for
 
         gmx trjcat

--- a/tools/gromacs/trj.xml
+++ b/tools/gromacs/trj.xml
@@ -31,14 +31,14 @@
         ln -s '$str_input' ./str.${str_input.ext} &&
         ln -s '$trj_input' ./traj.${trj_input.ext} &&
 
-    echo ## optionally pipe in the following
-	#if $trj.fit.fit != 'none':
-	    '$trj.fit.index_fit'
-    #end if
-    #if $trj.pbc.pbc == 'cluster':
-	    '$trj.pbc.index_cluster'
-    #end if
-    '$trj.index_center'	'$trj.index_output' | gmx trjconv
+        echo ## optionally pipe in the following
+        #if $trj.fit.fit != 'none':
+            '$trj.fit.index_fit'
+        #end if
+        #if $trj.pbc.pbc == 'cluster':
+            '$trj.pbc.index_cluster'
+        #end if
+        '$trj.index_center'	'$trj.index_output' | gmx trjconv
       	-f ./traj.${trj_input.ext}
         -s ./str.${str_input.ext}
         #if $ndx_input:


### PR DESCRIPTION
In #148 we discussed the problem of ordering trajectories for the `trjcat` tool. I believe the tool is in general already able to do this, if a collection is used as the input. There is a bug though; the tool iterates over inputs and symlinks to `traj_0.xtc`, `traj1.xtc` ... If there are more than 10 inputs, ordering is broken, as the trjcat command will place `traj10.xtc` between `traj1.xtc` and `traj2.xtc`.

To fix, we can simply use Python's `rjust` to pad 10 leading zeroes to the file index.

IIRC I was already aware of this bug when I wrote the tool 2-3 years ago, but couldn't work out how to add the leading zeroes in Cheetah :( In the end I just gave up and added the `Please note this tool does not currently take order into account` disclaimer. (For my own use case at the time, order wasn't that important.)

ping @thepineapplepirate