### PR TITLE
Updating tools/openmm from version 1.8.1 to 1.9

### DIFF
--- a/tools/openmm/pdbfixer.xml
+++ b/tools/openmm/pdbfixer.xml
@@ -1,7 +1,7 @@
 <tool id="pdbfixer" name="PDBFixer"  version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <description>to automatically fix a PDB file before performing molecular dynamics simulation</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.8.1</token>
+        <token name="@TOOL_VERSION@">1.9</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/openmm**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/openmm from version 1.8.1 to 1.9.

**Project home page:** https://github.com/openmm/releases

**Maintainers:** @simonbray

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).